### PR TITLE
Only recover the queries where outputBuffer size is zero

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/ArbitraryOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/ArbitraryOutputBuffer.java
@@ -544,4 +544,15 @@ public class ArbitraryOutputBuffer
         }
         return true;
     }
+
+    @Override
+    public boolean isAnyPagesAdded()
+    {
+        for (ClientBuffer partition : buffers.values()) {
+            if (partition.isAnyPageAdded()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/BroadcastOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/BroadcastOutputBuffer.java
@@ -440,4 +440,15 @@ public class BroadcastOutputBuffer
         }
         return true;
     }
+
+    @Override
+    public boolean isAnyPagesAdded()
+    {
+        for (ClientBuffer partition : buffers.values()) {
+            if (partition.isAnyPageAdded()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/ClientBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/ClientBuffer.java
@@ -113,6 +113,11 @@ class ClientBuffer
         return pages.isEmpty();
     }
 
+    public boolean isAnyPageAdded()
+    {
+        return pagesAdded.get() > 0;
+    }
+
     public void destroy()
     {
         List<SerializedPageReference> removedPages;

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/LazyOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/LazyOutputBuffer.java
@@ -413,4 +413,10 @@ public class LazyOutputBuffer
     {
         return delegate.isAllPagesConsumed();
     }
+
+    @Override
+    public boolean isAnyPagesAdded()
+    {
+        return delegate.isAnyPagesAdded();
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/OutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/OutputBuffer.java
@@ -142,4 +142,9 @@ public interface OutputBuffer
     {
         return false;
     }
+
+    default boolean isAnyPagesAdded()
+    {
+        return false;
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/PartitionedOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/PartitionedOutputBuffer.java
@@ -329,4 +329,15 @@ public class PartitionedOutputBuffer
         }
         return true;
     }
+
+    @Override
+    public boolean isAnyPagesAdded()
+    {
+        for (ClientBuffer partition : partitions) {
+            if (partition.isAnyPageAdded()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/SpoolingOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/SpoolingOutputBuffer.java
@@ -778,4 +778,10 @@ public class SpoolingOutputBuffer
     {
         return pages.isEmpty();
     }
+
+    @Override
+    public boolean isAnyPagesAdded()
+    {
+        return totalPagesAdded.get() > 0;
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/FaultInjector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/FaultInjector.java
@@ -20,7 +20,6 @@ import com.facebook.presto.server.ServerConfig;
 import com.facebook.presto.util.PeriodicTaskExecutor;
 import io.airlift.units.Duration;
 
-import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/HostShutDownListener.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/HostShutDownListener.java
@@ -17,5 +17,5 @@ import com.facebook.presto.execution.TaskId;
 
 public interface HostShutDownListener
 {
-    void handleShutdown(TaskId taskId);
+    void handleShutdown(TaskId taskId, boolean recovery);
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/MultilevelSplitQueue.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/MultilevelSplitQueue.java
@@ -26,8 +26,10 @@ import javax.inject.Inject;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.PriorityQueue;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
@@ -277,6 +279,24 @@ public class MultilevelSplitQueue
             for (PriorityQueue<PrioritizedSplitRunner> level : levelWaitingSplits) {
                 level.removeAll(splits);
             }
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public Set<TaskHandle> getTaskHandles()
+    {
+        lock.lock();
+        try {
+            Set<TaskHandle> tasks = new HashSet<>();
+            for (PriorityQueue<PrioritizedSplitRunner> level : levelWaitingSplits) {
+                for (PrioritizedSplitRunner split : level) {
+                    tasks.add(split.getTaskHandle());
+                }
+            }
+
+            return tasks;
         }
         finally {
             lock.unlock();

--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskHandle.java
@@ -188,12 +188,13 @@ public class TaskHandle
         isShuttingDown.set(true);
     }
 
-    public void handleShutDown()
+    public void handleShutDown(boolean recovery)
     {
         if (!hostShutDownListener.isPresent()) {
             return;
         }
-        hostShutDownListener.get().handleShutdown(taskId);
+
+        hostShutDownListener.get().handleShutdown(taskId, recovery);
     }
 
     public synchronized int getQueuedSplitSize()
@@ -224,6 +225,11 @@ public class TaskHandle
     public boolean isOutputBufferEmpty()
     {
         return outputBuffer.get().isAllPagesConsumed();
+    }
+
+    public boolean isAnyPageAdded()
+    {
+        return outputBuffer.get().isAnyPagesAdded();
     }
 
     public Optional<OutputBuffer> getOutputBuffer()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
@@ -340,7 +340,8 @@ public class TestSqlStageExecution
         assertFalse(stage.getStageExecutionInfo().getTasks().isEmpty());
         assertFalse(stage.noMoreRetry());
 
-        while (!recoveryIsRun.get());
+        while (!recoveryIsRun.get()) {
+        }
 
         MockRemoteTaskFactory.MockRemoteTask secondTask = (MockRemoteTaskFactory.MockRemoteTask) allTasks.get(1);
         secondTask.markAllSplitsRun();


### PR DESCRIPTION
Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
